### PR TITLE
Fix config import

### DIFF
--- a/src/js/emoji-picker.js
+++ b/src/js/emoji-picker.js
@@ -1,4 +1,4 @@
-import Config from "./Config"
+import Config from "./config"
 import {getGuid} from "./util"
 import ConfigStorage from "./ConfigStorage"
 /**


### PR DESCRIPTION
I use it with:  

```
yarn add https://github.com/one-signal/emoji-picker#2_0

import {EmojiPicker} from 'onesignal-emoji-picker/src'
```
And it fails on trying to load `./Config` instead of `./config`